### PR TITLE
Clasp supports now trivial-file-size

### DIFF
--- a/data.lisp
+++ b/data.lisp
@@ -117,7 +117,7 @@
 (trivial-file-size
  :link "https://github.com/ruricolist/trivial-file-size"
  :description "Query a file's size from its metadata."
- :support (:abcl :allegro :ccl :clisp :cmucl (:ecl :completion 0.5) :gcl (:lispworks :completion 0.5) :sbcl))
+ :support (:abcl :allegro :ccl :clasp :clisp :cmucl (:ecl :completion 0.5) :gcl (:lispworks :completion 0.5) :sbcl))
 
 (introspect-environment
  :link "https://github.com/Bike/introspect-environment"


### PR DESCRIPTION
* since commit https://github.com/ruricolist/trivial-file-size/commit/ded4e88f20694eb04c7843d4594cc97489b47753