### PR TITLE
Bring ECL support for TRIVIAL-CLTL2 up to date

### DIFF
--- a/data.lisp
+++ b/data.lisp
@@ -76,7 +76,7 @@
 (trivial-cltl2
  :link "https://github.com/Zulu-Inuoe/trivial-cltl2"
  :description "Some of the extensions described in CLtL2 that were not included in ANSI."
- :support (:abcl :allegro :ccl :cmucl :ecl :sbcl))
+ :support (:abcl :allegro :ccl :cmucl (:ecl :completion 0.125) :sbcl))
 
 (cl-environments
  :link "https://github.com/alex-gutev/cl-environments"


### PR DESCRIPTION
The only part of the TRIVIAL-CLTL2 API ECL supports is COMPILER-LET as of ECL 21.2.1.

```lisp
CL-USER> (ql:quickload :trivial-cltl2)
To load "trivial-cltl2":
  Load 1 ASDF system:
    trivial-cltl2
; Loading "trivial-cltl2"

(:TRIVIAL-CLTL2)
CL-USER> (loop for sym being the external-symbols in :trivial-cltl2
	       for supported = (fboundp sym)
	       collect (list sym supported))
((TRIVIAL-CLTL2:VARIABLE-INFORMATION NIL)
 (TRIVIAL-CLTL2:DECLARATION-INFORMATION NIL)
 (TRIVIAL-CLTL2:DEFINE-DECLARATION NIL) (TRIVIAL-CLTL2:PARSE-MACRO NIL)
 (TRIVIAL-CLTL2:FUNCTION-INFORMATION NIL)
 (EXT:COMPILER-LET T
   )
 (TRIVIAL-CLTL2:AUGMENT-ENVIRONMENT NIL) (TRIVIAL-CLTL2:ENCLOSE NIL))
CL-USER> 
```
Which is 1/8, hence 12.5%